### PR TITLE
Remove custom css webpack loader rules

### DIFF
--- a/config/webpack/custom.js
+++ b/config/webpack/custom.js
@@ -6,20 +6,4 @@ module.exports = {
       ReactDOM: 'react-dom',
     }
   },
-  module: {
-    rules: [
-      {
-        test: /\.css$/i,
-        use: [
-          "style-loader",
-          "css-loader"
-        ]
-      },
-      {
-        test: /\.s[ac]ss$/i,
-        use: ["css-loader", "postcss-loader", { loader: "sass-loader", options: { implementation: require("sass") } },
-        ],
-      },
-    ],
-  }
 }


### PR DESCRIPTION
Webpacker 6 will provide loader rules by default when css webpack
dependencies are detected. The custom loader rules were not set up
correctly to work with the rest of the webpack config.

Fixes rails/webpacker#2916 and makes your demo app CSS work
with Webpacker 6.