### PR TITLE
Fix webpack-dev-server auto-refresh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'pg', '~> 1.1'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 6.0.0.beta.5'
+gem 'webpacker', '6.0.0.beta.5'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -156,7 +156,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webpacker (6.0.0.pre.2)
+    webpacker (6.0.0.beta.5)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -182,7 +182,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)
-  webpacker (~> 6.0.0.beta.5)
+  webpacker (= 6.0.0.beta.5)
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/config/webpack/custom.js
+++ b/config/webpack/custom.js
@@ -6,20 +6,4 @@ module.exports = {
       ReactDOM: 'react-dom',
     }
   },
-  module: {
-    rules: [
-      {
-        test: /\.css$/i,
-        use: [
-          "style-loader",
-          "css-loader"
-        ]
-      },
-      {
-        test: /\.s[ac]ss$/i,
-        use: ["css-loader", "postcss-loader", { loader: "sass-loader", options: { implementation: require("sass") } },
-        ],
-      },
-    ],
-  }
 }

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -25,6 +25,8 @@ development:
     host: localhost
     port: 3035
     public: localhost:3035
+    # Inject browserside javascript that required by both HMR and Live(full) reload
+    inject_client: true
     # Hot Module Replacement updates modules while the application is running without a full reload
     hmr: false
     # Inline should be set to true if using HMR; it inserts a script to take care of live reloading


### PR DESCRIPTION
There were two issues: the webpacker gem version was out-of-date with the @rails/webpacker NPM package and the config/webpacker.yml was missing the critical option to enable auto-refresh for webpack 5 (with which Webpacker 6 integrates).

Note: the beta Webpacker releases are more recent, but Bundler treats the pre release as the primary release. In this case, you want the beta release which has the fixes you need.